### PR TITLE
feat: github 로그인, httponly 쿠키 저장 로직 구현(#42)

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -16,6 +16,7 @@ module.exports = {
         'ci', // CI 설정 파일 수정
         'build', // 빌드 시스템 또는 외부 의존성 변경
         'revert', // 이전 커밋 되돌리기
+        'core', // 핵심 기능 관련 변경사항
       ],
     ],
     'type-case': [2, 'always', 'lower-case'],

--- a/src/app/api/auth/github/callback/route.ts
+++ b/src/app/api/auth/github/callback/route.ts
@@ -1,7 +1,40 @@
-// src/app/api/auth/github/callback/route.ts
-import { NextResponse } from 'next/server';
+import { NextRequest, NextResponse } from 'next/server';
 
-export async function GET() {
-  // 여기에 GitHub 콜백 로직을 구현할 예정
-  return NextResponse.json({ message: 'GitHub Callback' });
+export async function GET(req: NextRequest) {
+  const code = req.nextUrl.searchParams.get('code');
+
+  if (!code) {
+    return NextResponse.json({ messege: '코드가 없습니다.' }, { status: 400 });
+  }
+
+  // 받은 code를 access token으로 교환
+  const tokenRes = await fetch('https://github.com/login/oauth/access_token', {
+    method: 'POST',
+    headers: {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      client_id: process.env.GITHUB_CLIENT_ID,
+      client_secret: process.env.GITHUB_CLIENT_SECRET,
+      code,
+    }),
+  });
+  const tokenData = await tokenRes.json();
+  const accessToken = tokenData.access_token;
+
+  if (!accessToken) {
+    return NextResponse.json({ messege: '토큰 에러' }, { status: 400 });
+  }
+  const response = NextResponse.redirect(new URL('/', req.url));
+
+  response.cookies.set({
+    name: 'github_access_token',
+    value: accessToken,
+    httpOnly: true,
+    secure: process.env.NODE_ENV === 'production',
+    sameSite: 'lax',
+    path: '/',
+  });
+  return response;
 }

--- a/src/app/api/auth/github/route.ts
+++ b/src/app/api/auth/github/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const params = new URLSearchParams({
+    client_id: process.env.GITHUB_CLIENT_ID!,
+    redirect_uri: process.env.GITHUB_REDIRECT_URI!,
+    scope: 'read:user user:email',
+  });
+  const githubAuthUrl = `https://github.com/login/oauth/authorize?${params.toString()}`;
+  return NextResponse.redirect(githubAuthUrl);
+}


### PR DESCRIPTION
## 📌 PR 개요

- 깃허브 로그인, 로그인 후 콜백으로 code -> access_token 변환 로직 구현

## 🔍 관련 이슈

- Closes #42
## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 주요 변경 내용을 리스트로 정리해주세요.

`ex`

- 로그인 API 연동 (`/api/login`) 추가
- 로그인 폼에서 이메일/비밀번호 유효성 검사 로직 추가
- 로그인 성공 시 JWT 토큰을 localStorage에 저장하도록 수정
- UI: 로그인 버튼 클릭 시 로딩 스피너 추가

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [ ] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * GitHub 계정을 이용한 OAuth 인증 기능 추가
  * 보안이 강화된 토큰 및 쿠키 관리 시스템 구현

* **개선사항**
  * 인증 프로세스의 오류 처리 강화
  * GitHub OAuth 콜백 안정성 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->