### PR TITLE
fix: serverApi 인증 로직을 자체 users 기반으로 전환 (#51)

### DIFF
--- a/src/shared/api/server/serverApi.ts
+++ b/src/shared/api/server/serverApi.ts
@@ -1,5 +1,4 @@
 import { z } from 'zod';
-import { cookies } from 'next/headers';
 import { ApiError } from './../error/ApiError';
 
 // serverApi 옵션 타입 정의
@@ -9,39 +8,13 @@ interface RequestConfig<T = unknown> {
   headers?: Record<string, string>;
   cache?: RequestCache;
   schema?: z.ZodType<T>;
-  useAuth?: boolean;
-  apiType?: 'rest' | 'auth';
 }
 
 export async function serverApi<T>(path: string, config: RequestConfig<T> = {}): Promise<T> {
-  const {
-    method = 'GET',
-    body,
-    headers = {},
-    cache = 'no-store',
-    schema,
-    useAuth = false,
-    apiType = 'rest',
-  } = config;
+  const { method = 'GET', body, headers = {}, cache = 'no-store', schema } = config;
 
-  // API 타입에 따른 base URL
-  const baseUrl =
-    apiType === 'auth'
-      ? `${process.env.NEXT_PUBLIC_API_BASE_URL}/auth/v1`
-      : `${process.env.NEXT_PUBLIC_API_BASE_URL}/rest/v1`;
-
-  // 사용자 토큰 가져오기
-  let authHeader = `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY!}`;
-
-  if (useAuth) {
-    const cookieStore = await cookies();
-    const accessToken = cookieStore.get('accessToken')?.value;
-
-    if (!accessToken) {
-      throw new ApiError(401, 'Unauthorized');
-    }
-    authHeader = `Bearer ${accessToken}`;
-  }
+  // base URL
+  const baseUrl = `${process.env.NEXT_PUBLIC_API_BASE_URL}/rest/v1`;
 
   // fetch에 넘길 옵션 객체 생성
   const fetchOptions: RequestInit = {
@@ -50,7 +23,7 @@ export async function serverApi<T>(path: string, config: RequestConfig<T> = {}):
     headers: {
       'Content-Type': 'application/json',
       apikey: process.env.SUPABASE_SERVICE_ROLE_KEY!,
-      Authorization: authHeader,
+      Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE_KEY!}`,
       ...headers,
     },
   };
@@ -75,7 +48,6 @@ export async function serverApi<T>(path: string, config: RequestConfig<T> = {}):
   if (schema) {
     const result = schema.safeParse(data);
     if (!result.success) {
-      console.error('Schema validation failed:', result.error.flatten());
       throw new ApiError(500, 'Response validation failed');
     }
     return result.data;


### PR DESCRIPTION
## 📌 PR 개요

- 쿠키인증, useAuth제거

## 🔍 관련 이슈

- Closes #51 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [ ] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [x] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- Supabase Auth API 의존성을 제거하고, serverApi를 Supabase REST 전용 데이터 접근 레이어로 정리했습니다.
- 인증 여부 판단 로직을 serverApi에서 분리하고, 미들웨어에서 단일 책임으로 처리하도록 변경했습니다.
- serverApi에서 쿠키 및 토큰 검증 로직을 제거해 역할을 단순화했습니다.
- 사용자 식별은 토큰에 포함된 user_id를 기준으로 Route Handler에서 users 테이블을 조회하는 구조로 전환했습니다.
- 인증이 필요한 영역과 공개 영역을 명확히 분리할 수 있는 기반을 정리했습니다.

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [ ] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 유저 정보는 DB에서 직접 찾는 개념이 아니라, 토큰을 기준으로 식별해서 조회한다.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 서버 API 요청 처리 로직을 최적화하고 표준화했습니다.
  * 인증 및 네트워크 통신 방식이 단순화되었습니다.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->