### PR TITLE
feat: 프롬프트 옵션 프리셋 저장 및 불러오기 기능 구현 (#127)

### DIFF
--- a/README3.md
+++ b/README3.md
@@ -1,0 +1,64 @@
+좋은 질문입니다! JavaScript의 **객체 참조(reference) 비교** 때문입니다.
+
+## 문제 상황:
+
+```typescript
+// ❌ 항상 새 객체를 생성
+setSelectFilters: (data) =>
+  set(() => ({
+    selectedFilters: data, // 새로운 state 객체
+  }));
+```
+
+## 왜 업데이트가 되는가?
+
+JavaScript는 객체를 **참조**로 비교합니다:
+
+```javascript
+// 내용은 같지만 다른 참조
+const filter1 = { documentType: ['blog'] };
+const filter2 = { documentType: ['blog'] };
+
+filter1 === filter2; // ❌ false! (다른 객체)
+
+// 같은 참조
+const filter3 = filter1;
+filter1 === filter3; // ✅ true (같은 객체)
+```
+
+## Zustand의 동작:
+
+```typescript
+// 1. 현재 state
+state = { selectedFilters: { documentType: ['blog'] } };
+
+// 2. setSelectFilters 호출
+setSelectFilters({ documentType: ['blog'] });
+
+// 3. set() 함수가 새 객체 생성
+newState = { selectedFilters: { documentType: ['blog'] } };
+
+// 4. Zustand가 참조 비교
+state !== newState; // ❌ true! (다른 참조)
+
+// 5. 구독자들에게 알림 → 리렌더링 🔄
+```
+
+## 해결:
+
+```typescript
+setSelectFilters: (data) =>
+  set((state) => {
+    // ✅ 내용 비교 (JSON 문자열)
+    if (JSON.stringify(state.selectedFilters) === JSON.stringify(data)) {
+      return state; // 같은 참조 반환 → 리렌더링 안 함
+    }
+
+    // 실제로 다르면 새 객체 생성
+    return {
+      selectedFilters: data,
+    };
+  });
+```
+
+**즉, 내용이 같아도 `set()`을 호출하면 항상 새 객체가 만들어져서 "변경됨"으로 인식됩니다!**

--- a/src/app/api/presets/route.ts
+++ b/src/app/api/presets/route.ts
@@ -1,0 +1,26 @@
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+import { verifyAccessToken } from '@/shared/auth/verifyAccessToken';
+import { serverApi } from '@/shared/api/server/serverApi';
+
+export async function GET() {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('access_token')?.value;
+
+  if (!accessToken) {
+    return NextResponse.json({ message: '로그인이 필요합니다.' }, { status: 401 });
+  }
+
+  try {
+    const { user_id } = verifyAccessToken(accessToken);
+    console.log(user_id);
+    const data = await serverApi(`/saved_filters?user_id=eq.${user_id}&select=id,name,filters`);
+    return NextResponse.json(data);
+  } catch (error) {
+    console.log('에러', error);
+    return NextResponse.json(
+      { message: '데이터 불러오는데 실패했습니다.Accordion' },
+      { status: 401 },
+    );
+  }
+}

--- a/src/app/api/saved-filters/route.ts
+++ b/src/app/api/saved-filters/route.ts
@@ -1,0 +1,37 @@
+import { cookies } from 'next/headers';
+import { NextRequest, NextResponse } from 'next/server';
+import { verifyAccessToken } from '@/shared/auth/verifyAccessToken';
+import { serverApi } from '@/shared/api/server/serverApi';
+
+export async function POST(req: NextRequest) {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('access_token')?.value;
+
+  if (!accessToken) {
+    return NextResponse.json({ message: '로그인이 필요합니다.' }, { status: 401 });
+  }
+
+  try {
+    const { user_id } = verifyAccessToken(accessToken);
+    const { name, filters } = await req.json();
+    console.log(user_id, name, filters);
+
+    await serverApi('/saved_filters', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+      body: {
+        user_id: user_id,
+        name: name,
+        filters: filters,
+      },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (e) {
+    console.log(e);
+    return NextResponse.json({ message: '저장 실패' }, { status: 500 });
+  }
+}

--- a/src/features/filter-selected-list/FilterSelectedList.tsx
+++ b/src/features/filter-selected-list/FilterSelectedList.tsx
@@ -1,26 +1,19 @@
 'use client';
 import { Badge } from './Badge';
 import { usePromptFilterStore } from '@/shared/stores/usePromptFilterStore';
-import { FILTERS } from '../prompt-filter/constants/options';
 import { PromptFilterCategory, PromptFilterKey } from '../prompt-filter/types';
 export const FilterSelectedList = () => {
-  const { selectedFilters, removeFilter } = usePromptFilterStore();
-  const flatFilter = Object.entries(selectedFilters).flatMap(([category, keys]) =>
-    keys.map((key) => ({
-      category: category as PromptFilterCategory,
-      key: key as PromptFilterKey,
-      label: FILTERS[category as PromptFilterCategory].options.find((opt) => opt.key === key)
-        ?.label,
-    })),
-  );
-  console.log('selectedFilters', selectedFilters);
-  console.log('flatFilter', flatFilter);
+  const { removeFilter, selectedFilters } = usePromptFilterStore();
+  const getFlatFilters = usePromptFilterStore((state) => state.getFlatFilters);
+  const flatFilters = getFlatFilters();
 
-  if (flatFilter.length === 0) return null;
+  console.log('flatFilters', flatFilters);
+  console.log('selectedFilters', selectedFilters);
+  if (flatFilters.length === 0) return null;
 
   return (
     <div className="flex flex-wrap gap-2 bg-gray-100 p-2 rounded-lg">
-      {flatFilter.map((item) => (
+      {flatFilters.map((item) => (
         <Badge
           key={item.key}
           label={item.label}

--- a/src/features/filter-selected-list/FilterSeletedListWrap.tsx
+++ b/src/features/filter-selected-list/FilterSeletedListWrap.tsx
@@ -1,16 +1,40 @@
+'use client';
+
 import { FilterContainer } from '../prompt-filter/ui/FilterContainer';
 import { FilterSelectedList } from './FilterSelectedList';
 import Button from '@/shared/ui/Button';
+import { SaveFilterModal } from './SaveFilterModal';
+import { Modal } from '@/shared/ui/modal/ModalRoot';
+import { useModal } from '@/shared/ui/modal/ModalProvider';
+import { useSaveFilters } from './hooks/useSaveFilters';
+
 export const FilterSelectedListWrap = () => {
+  const { open, close } = useModal();
+  const { data } = useSaveFilters();
+
+  console.log('data', data);
+  const handleSaveFilter = () => {
+    const id = open({
+      component: (
+        <Modal.Content>
+          <Modal.Body>
+            <SaveFilterModal onClose={() => close(id)} />
+          </Modal.Body>
+        </Modal.Content>
+      ),
+    });
+  };
+
   return (
     <section className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-lg font-semibold">문서 생성 옵션</h2>
-        <Button>필터 저장</Button>
+        <Button variant="gray" onClick={handleSaveFilter}>
+          필터 저장
+        </Button>
       </div>
       <FilterContainer />
       <FilterSelectedList />
-      {/* 1칭찬^^ */}
     </section>
   );
 };

--- a/src/features/filter-selected-list/SaveFilterModal.tsx
+++ b/src/features/filter-selected-list/SaveFilterModal.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import { useState } from 'react';
+import Button from '@/shared/ui/Button';
+import Input from '@/shared/ui/input/Input';
+import { Modal } from '@/shared/ui/modal/ModalRoot';
+import { FilterSelectedList } from './FilterSelectedList';
+import { modal } from '@/shared/ui/modal/modalApi';
+import { usePromptFilterStore } from '@/shared/stores/usePromptFilterStore';
+import { PromptFilterCategory, PromptFilterKey } from '../prompt-filter/types';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { clientApi } from '@/shared/api/client/clientApi';
+
+export type SaveFilterModalProps = {
+  onClose: () => void;
+};
+
+type CreatePresetPayload = {
+  name: string;
+  filters: Partial<Record<PromptFilterCategory, PromptFilterKey[]>>;
+};
+
+export const SaveFilterModal = ({ onClose }: SaveFilterModalProps) => {
+  const [filterName, setFilterName] = useState('');
+  const queryClient = useQueryClient();
+  const { selectedFilters } = usePromptFilterStore();
+
+  const savePresetMutation = useMutation({
+    mutationFn: async (payload: CreatePresetPayload) => {
+      return clientApi('/saved-filters', {
+        method: 'POST',
+        body: payload,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['presets'] });
+      onClose();
+    },
+  });
+
+  const handleSave = () => {
+    const name = filterName.trim();
+    if (!name) {
+      modal.alert('이름을 입력해주세요');
+      return;
+    }
+
+    savePresetMutation.mutate({
+      name,
+      filters: selectedFilters,
+    });
+    onClose();
+  };
+
+  return (
+    <>
+      <Modal.Header>필터 저장</Modal.Header>
+      <p>현재 선택한 필터를 프리셋으로 저장합니다. 나중에 프리셋에서 바로 불러올 수 있어요.</p>
+      <Modal.Body>
+        <Input
+          placeholder="프리셋 이름을 입력하세요"
+          value={filterName}
+          onChange={(e) => setFilterName(e.target.value)}
+        />
+        <FilterSelectedList />
+      </Modal.Body>
+      <Modal.Footer>
+        <div className="flex gap-2">
+          <Button variant="secondary" className="flex-1" onClick={onClose}>
+            취소
+          </Button>
+          <Button className="flex-1" onClick={handleSave}>
+            저장
+          </Button>
+        </div>
+      </Modal.Footer>
+    </>
+  );
+};

--- a/src/features/filter-selected-list/SaveFilterPopover.tsx
+++ b/src/features/filter-selected-list/SaveFilterPopover.tsx
@@ -1,0 +1,26 @@
+import { Popover, PopoverTrigger, PopoverContent, PopoverClose } from '@/shared/ui/popover';
+import { useSaveFilters } from './hooks/useSaveFilters';
+
+import Button from '@/shared/ui/Button';
+import { usePromptFilterStore } from '@/shared/stores/usePromptFilterStore';
+export const SaveFilterPopover = () => {
+  const { data } = useSaveFilters();
+  const setSelectFilters = usePromptFilterStore((s) => s.setSelectFilters);
+  if (!data) return null;
+  return (
+    <div>
+      <Popover>
+        <PopoverTrigger>⭐ 저장된 필터</PopoverTrigger>
+        <PopoverContent align="start">
+          <ul>
+            {data.map((filter) => (
+              <li key={filter.id}>
+                <Button onClick={() => setSelectFilters(filter.filters)}>{filter.name}</Button>
+              </li>
+            ))}
+          </ul>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+};

--- a/src/features/filter-selected-list/hooks/useSaveFilters.ts
+++ b/src/features/filter-selected-list/hooks/useSaveFilters.ts
@@ -1,0 +1,18 @@
+import { useQuery } from '@tanstack/react-query';
+import { clientApi } from '@/shared/api/client/clientApi';
+import { PromptFilterKey, PromptFilterCategory } from '@/features/prompt-filter/types';
+
+interface PresetsType {
+  id: number;
+  name: string;
+  filters: Partial<Record<PromptFilterCategory, PromptFilterKey[]>>;
+}
+
+export const useSaveFilters = () => {
+  return useQuery({
+    queryKey: ['presets'],
+    queryFn: async () => {
+      return clientApi<PresetsType[]>('presets');
+    },
+  });
+};

--- a/src/features/prompt-filter/ui/FilterContainer.tsx
+++ b/src/features/prompt-filter/ui/FilterContainer.tsx
@@ -4,7 +4,7 @@ import { FILTERS } from '../constants/options';
 import type { PromptFilterCategory } from '../types';
 import { FilterPopover } from './PromptFilterPopover';
 import { usePromptFilterStore } from '@/shared/stores/usePromptFilterStore';
-
+import { SaveFilterPopover } from './../../filter-selected-list/SaveFilterPopover';
 export function FilterContainer() {
   const { toggleFilter, isChecked } = usePromptFilterStore();
 
@@ -13,22 +13,26 @@ export function FilterContainer() {
   const totalCount = categories.length;
 
   return (
-    <div className="grid grid-cols-2 gap-2 md:grid-cols-3 lg:flex">
-      {categories.map((category, index) => {
-        const align = index >= totalCount / 2 ? 'end' : 'start';
-        const isSingleSelect = category === 'documentType';
-        return (
-          <FilterPopover
-            key={category}
-            label={FILTERS[category].label}
-            options={FILTERS[category].options}
-            isChecked={(key) => isChecked(category, key)}
-            onToggle={(key) => toggleFilter(category, key)}
-            align={align} // 계산된 align 전달
-            isSingleSelect={isSingleSelect}
-          />
-        );
-      })}
+    <div className="flex flex-col gap-2">
+      <SaveFilterPopover />
+      <div className="grid grid-cols-2 gap-2 md:grid-cols-3 lg:flex">
+        {categories.map((category, index) => {
+          const align = index >= totalCount / 2 ? 'end' : 'start';
+          const isSingleSelect = category === 'documentType';
+
+          return (
+            <FilterPopover
+              key={category}
+              label={FILTERS[category].label}
+              options={FILTERS[category].options}
+              isChecked={(key) => isChecked(category, key)}
+              onToggle={(key) => toggleFilter(category, key)}
+              align={align} // 계산된 align 전달
+              isSingleSelect={isSingleSelect}
+            />
+          );
+        })}
+      </div>
     </div>
   );
 }

--- a/src/shared/api/server/serverApi.ts
+++ b/src/shared/api/server/serverApi.ts
@@ -40,7 +40,11 @@ export async function serverApi<T>(path: string, config: RequestConfig<T> = {}):
   }
 
   // No Content 응답 대응
-  if (res.status === 204) return null as T;
+  if (res.status === 204 || res.status === 201) {
+    const text = await res.text();
+    if (!text) return null as T;
+    return JSON.parse(text) as T;
+  }
 
   const data = await res.json();
 

--- a/src/shared/stores/usePromptFilterStore.ts
+++ b/src/shared/stores/usePromptFilterStore.ts
@@ -1,14 +1,20 @@
 import { create } from 'zustand';
 import { devtools } from 'zustand/middleware';
 import { PromptFilterKey, PromptFilterCategory } from '@/features/prompt-filter/types';
+import { FILTERS } from '@/features/prompt-filter/constants/options';
 interface PomptFilterStore {
   // 필터 상태: { documentType: ['readme'], purpose: ['overview', 'usage'].filter(item => item !== key) }
   selectedFilters: Partial<Record<PromptFilterCategory, PromptFilterKey[]>>;
-
+  setSelectFilters: (data: Partial<Record<PromptFilterCategory, PromptFilterKey[]>>) => void;
   isChecked: (category: PromptFilterCategory, key: PromptFilterKey) => boolean;
   toggleFilter: (category: PromptFilterCategory, key: PromptFilterKey) => void;
   removeFilter: (category: PromptFilterCategory, key: PromptFilterKey) => void;
   resetFilters: () => void;
+  getFlatFilters: () => {
+    category: PromptFilterCategory;
+    key: PromptFilterKey;
+    label: string | undefined;
+  }[];
 }
 
 export const usePromptFilterStore = create<PomptFilterStore>()(
@@ -16,6 +22,15 @@ export const usePromptFilterStore = create<PomptFilterStore>()(
     selectedFilters: {
       documentType: ['blog'],
     },
+    setSelectFilters: (data) =>
+      set((state) => {
+        if (JSON.stringify(state.selectedFilters) === JSON.stringify(data)) {
+          return state;
+        }
+        return {
+          selectedFilters: data,
+        };
+      }),
     isChecked: (category, key) => {
       return get().selectedFilters[category]?.includes(key) ?? false;
     },
@@ -52,5 +67,23 @@ export const usePromptFilterStore = create<PomptFilterStore>()(
         };
       }),
     resetFilters: () => set({ selectedFilters: {} }),
+    getFlatFilters: () => {
+      const filters = get().selectedFilters;
+
+      const allFilters = Object.entries(filters).flatMap(([category, keys]) =>
+        keys.map((key) => ({
+          category: category as PromptFilterCategory,
+          key: key as PromptFilterKey,
+          label: FILTERS[category as PromptFilterCategory].options.find((opt) => opt.key === key)
+            ?.label,
+        })),
+      );
+
+      // documentType 따로 분리
+      const docTypeFilters = allFilters.filter((f) => f.category === 'documentType');
+      const otherFilters = allFilters.filter((f) => f.category !== 'documentType');
+
+      return [...docTypeFilters, ...otherFilters];
+    },
   })),
 );

--- a/src/shared/ui/Button.tsx
+++ b/src/shared/ui/Button.tsx
@@ -61,7 +61,7 @@ const base =
   'disabled:pointer-events-none disabled:opacity-50';
 
 const primary = 'bg-primary text-white hover:bg-primary-hover';
-const secondary = 'bg-secondary text-white border hover:bg-secondary-hover';
+const secondary = 'bg-slate-200 text-slate-900 hover:bg-slate-300 transition-colors';
 const gray = 'bg-white text-gray-900 border border-gray-300 hover:bg-gray-50';
 const github = 'bg-gray-900 text-white hover:bg-gray-800 shadow-sm';
 


### PR DESCRIPTION
## 📌 PR 개요

- 프롬프트 옵션 프리셋 저장 및 불러오기 기능 구현

## 🔍 관련 이슈

- Closes #127

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

* 프롬프트 필터 프리셋 저장 기능 구현

  * 모달에서 이름 입력 후 현재 선택 필터 저장
  * 서버에서 access_token 기반 user_id 추출 후 DB 저장
* Supabase `saved_filters` 테이블 연동

  * user_id 기반 저장 및 조회
* React Query 적용

  * `useMutation`으로 저장 처리
  * 저장 성공 시 `invalidateQueries(['presets'])`로 목록 갱신
  * `useQuery`로 프리셋 목록 조회
* 저장된 프리셋 Popover UI 구현

  * 프리셋 클릭 시 Zustand `selectedFilters` 통째로 덮어쓰기
* Zustand에 `setSelectedFilters` 액션 추가

---

### 주요 흐름

저장
→ SaveFilterModal
→ useMutation
→ /api/saved-filters POST
→ DB 저장
→ presets 자동 갱신

적용
→ 저장된 프리셋 클릭
→ setSelectedFilters(preset.filters)
→ 현재 필터 상태 변경

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [ ] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 필터 프리셋 저장 기능 추가 - 현재 선택된 필터를 이름으로 저장할 수 있습니다.
  * 저장된 필터 불러오기 기능 추가 - 이전에 저장한 필터 프리셋을 한 번에 적용할 수 있습니다.

* **스타일**
  * 필터 저장 버튼 스타일 개선 및 통일성 강화

* **문서**
  * 필터 객체 참조 동작에 대한 설명 문서 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->