### PR TITLE
feat: 저장된 프롬프트 필터 삭제 구현(#129)

### DIFF
--- a/README3.md
+++ b/README3.md
@@ -1,64 +1,33 @@
-좋은 질문입니다! JavaScript의 **객체 참조(reference) 비교** 때문입니다.
+import { serverApi } from '@/shared/api/server/serverApi';
+import { NextResponse, NextRequest } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifyAccessToken } from '@/shared/auth/verifyAccessToken';
 
-## 문제 상황:
+export async function DELETE(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+const cookieStore = await cookies();
+const accessToken = cookieStore.get('access_token')?.value;
 
-```typescript
-// ❌ 항상 새 객체를 생성
-setSelectFilters: (data) =>
-  set(() => ({
-    selectedFilters: data, // 새로운 state 객체
-  }));
-```
+if (!accessToken) {
+return NextResponse.json({ message: '로그인이 필요합니다.' }, { status: 401 });
+}
+try {
+const { user_id } = verifyAccessToken(accessToken);
+const { id } = await context.params;
+const numericId = Number(id);
 
-## 왜 업데이트가 되는가?
+    await serverApi(`saved_filters?id=eq.${numericId}&user_id=eq.${user_id}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
 
-JavaScript는 객체를 **참조**로 비교합니다:
+    return NextResponse.json({ ok: true });
 
-```javascript
-// 내용은 같지만 다른 참조
-const filter1 = { documentType: ['blog'] };
-const filter2 = { documentType: ['blog'] };
-
-filter1 === filter2; // ❌ false! (다른 객체)
-
-// 같은 참조
-const filter3 = filter1;
-filter1 === filter3; // ✅ true (같은 객체)
-```
-
-## Zustand의 동작:
-
-```typescript
-// 1. 현재 state
-state = { selectedFilters: { documentType: ['blog'] } };
-
-// 2. setSelectFilters 호출
-setSelectFilters({ documentType: ['blog'] });
-
-// 3. set() 함수가 새 객체 생성
-newState = { selectedFilters: { documentType: ['blog'] } };
-
-// 4. Zustand가 참조 비교
-state !== newState; // ❌ true! (다른 참조)
-
-// 5. 구독자들에게 알림 → 리렌더링 🔄
-```
-
-## 해결:
-
-```typescript
-setSelectFilters: (data) =>
-  set((state) => {
-    // ✅ 내용 비교 (JSON 문자열)
-    if (JSON.stringify(state.selectedFilters) === JSON.stringify(data)) {
-      return state; // 같은 참조 반환 → 리렌더링 안 함
-    }
-
-    // 실제로 다르면 새 객체 생성
-    return {
-      selectedFilters: data,
-    };
-  });
-```
-
-**즉, 내용이 같아도 `set()`을 호출하면 항상 새 객체가 만들어져서 "변경됨"으로 인식됩니다!**
+} catch (e) {
+console.log(e);
+return NextResponse.json({ message: '데이터 삭제에 실패했습니다.' }, { status: 401 });
+}
+}

--- a/src/app/api/delete-filters/[id]/route.ts
+++ b/src/app/api/delete-filters/[id]/route.ts
@@ -1,0 +1,35 @@
+import { serverApi } from '@/shared/api/server/serverApi';
+import { NextResponse, NextRequest } from 'next/server';
+import { cookies } from 'next/headers';
+import { verifyAccessToken } from '@/shared/auth/verifyAccessToken';
+
+export async function DELETE(request: NextRequest, context: { params: Promise<{ id: string }> }) {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('access_token')?.value;
+
+  if (!accessToken) {
+    return NextResponse.json({ message: '로그인이 필요합니다.' }, { status: 401 });
+  }
+
+  try {
+    const { user_id } = verifyAccessToken(accessToken);
+    const { id } = await context.params;
+
+    await serverApi(`/saved_filters?id=eq.${id}&user_id=eq.${user_id}`, {
+      method: 'DELETE',
+      headers: {
+        'Content-Type': 'application/json',
+        Prefer: 'return=representation',
+      },
+    });
+
+    return NextResponse.json({ ok: true });
+  } catch (e: any) {
+    console.error('삭제 실패 상세 로그:', e.message || e);
+
+    return NextResponse.json(
+      { message: '데이터 삭제에 실패했습니다.', detail: e.message },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/presets/route.ts
+++ b/src/app/api/presets/route.ts
@@ -16,11 +16,8 @@ export async function GET() {
     console.log(user_id);
     const data = await serverApi(`/saved_filters?user_id=eq.${user_id}&select=id,name,filters`);
     return NextResponse.json(data);
-  } catch (error) {
-    console.log('에러', error);
-    return NextResponse.json(
-      { message: '데이터 불러오는데 실패했습니다.Accordion' },
-      { status: 401 },
-    );
+  } catch (e) {
+    console.log('에러', e);
+    return NextResponse.json({ message: '데이터 불러오기에 실패했습니다.' }, { status: 401 });
   }
 }

--- a/src/features/filter-selected-list/SaveFilterPopover.tsx
+++ b/src/features/filter-selected-list/SaveFilterPopover.tsx
@@ -1,21 +1,66 @@
+'use client';
 import { Popover, PopoverTrigger, PopoverContent, PopoverClose } from '@/shared/ui/popover';
 import { useSaveFilters } from './hooks/useSaveFilters';
-
-import Button from '@/shared/ui/Button';
+import { PromptFilterKey, PromptFilterCategory } from '@/features/prompt-filter/types';
+import { TrashIcon } from '@/shared/assets/icons/TrashIcon';
 import { usePromptFilterStore } from '@/shared/stores/usePromptFilterStore';
+import { useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { clientApi } from '@/shared/api/client/clientApi';
 export const SaveFilterPopover = () => {
   const { data } = useSaveFilters();
-  const setSelectFilters = usePromptFilterStore((s) => s.setSelectFilters);
+  const setSelectedFilters = usePromptFilterStore((s) => s.setSelectedFilters);
+  const queryClient = useQueryClient();
+  const [open, setOpen] = useState(false);
+
+  const handleSelectFilter = (filter: Partial<Record<PromptFilterCategory, PromptFilterKey[]>>) => {
+    setSelectedFilters(filter);
+    setOpen(false);
+  };
+
+  const deletePresetMutation = useMutation({
+    mutationFn: async (id: number) => {
+      return clientApi(`/delete-filters/${id}`, {
+        method: 'DELETE',
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['presets'] });
+    },
+  });
+  const handleDelete = (id: number) => {
+    deletePresetMutation.mutate(id);
+  };
   if (!data) return null;
   return (
     <div>
-      <Popover>
+      <Popover open={open} onOpenChange={setOpen}>
         <PopoverTrigger>⭐ 저장된 필터</PopoverTrigger>
-        <PopoverContent align="start">
-          <ul>
+        {/* 팝오버 너비 및 패딩 설정 */}
+        <PopoverContent align="start" className="w-72 p-2">
+          <ul className=" max-h-[300px] overflow-y-auto">
             {data.map((filter) => (
-              <li key={filter.id}>
-                <Button onClick={() => setSelectFilters(filter.filters)}>{filter.name}</Button>
+              <li
+                key={filter.id}
+                className="group flex items-center justify-between hover:bg-slate-100 transition-colors border-b-1 border-gray-200"
+              >
+                {/* 필터 선택 버튼 */}
+                <button
+                  onClick={() => handleSelectFilter(filter.filters)}
+                  className="flex-1 text-left px-3 py-2 text-md text-slate-700 truncate outline-none rounded-md focus-visible:ring-2 focus-visible:ring-primary cursor-pointer"
+                  title={filter.name}
+                >
+                  {filter.name}
+                </button>
+
+                {/* 삭제 버튼 (평소엔 숨김, 호버/포커스 시 표시) */}
+                <button
+                  onClick={() => handleDelete(filter.id)}
+                  className="p-2 text-slate-400 hover:text-red-600 hover:bg-red-50 rounded-md outline-none cursor-pointer"
+                  aria-label={`${filter.name} 삭제`}
+                >
+                  <TrashIcon className="w-5 h-5" />
+                </button>
               </li>
             ))}
           </ul>

--- a/src/shared/assets/icons/TrashIcon.tsx
+++ b/src/shared/assets/icons/TrashIcon.tsx
@@ -1,0 +1,16 @@
+export const TrashIcon = ({ className }: { className?: string }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    fill="none"
+    viewBox="0 0 24 24"
+    strokeWidth={1.5}
+    stroke="currentColor"
+    className={className}
+  >
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M14.74 9l-.346 9m-4.788 0L9.26 9m9.968-3.21c.342.052.682.107 1.022.166m-1.022-.165L18.16 19.673a2.25 2.25 0 01-2.244 2.077H8.084a2.25 2.25 0 01-2.244-2.077L4.772 5.79m14.456 0a48.108 48.108 0 00-3.478-.397m-12 .562c.34-.059.68-.114 1.022-.165m0 0a48.11 48.11 0 013.478-.397m7.5 0v-.916c0-1.18-.91-2.164-2.09-2.201a51.964 51.964 0 00-3.32 0c-1.18.037-2.09 1.022-2.09 2.201v.916m7.5 0a48.667 48.667 0 00-7.5 0"
+    />
+  </svg>
+);

--- a/src/shared/stores/usePromptFilterStore.ts
+++ b/src/shared/stores/usePromptFilterStore.ts
@@ -5,7 +5,8 @@ import { FILTERS } from '@/features/prompt-filter/constants/options';
 interface PomptFilterStore {
   // 필터 상태: { documentType: ['readme'], purpose: ['overview', 'usage'].filter(item => item !== key) }
   selectedFilters: Partial<Record<PromptFilterCategory, PromptFilterKey[]>>;
-  setSelectFilters: (data: Partial<Record<PromptFilterCategory, PromptFilterKey[]>>) => void;
+  setSelectedFilters: (data: Partial<Record<PromptFilterCategory, PromptFilterKey[]>>) => void;
+  removeSelectedFilter: (data: Partial<Record<PromptFilterCategory, PromptFilterKey[]>>) => void;
   isChecked: (category: PromptFilterCategory, key: PromptFilterKey) => boolean;
   toggleFilter: (category: PromptFilterCategory, key: PromptFilterKey) => void;
   removeFilter: (category: PromptFilterCategory, key: PromptFilterKey) => void;
@@ -22,7 +23,7 @@ export const usePromptFilterStore = create<PomptFilterStore>()(
     selectedFilters: {
       documentType: ['blog'],
     },
-    setSelectFilters: (data) =>
+    setSelectedFilters: (data) =>
       set((state) => {
         if (JSON.stringify(state.selectedFilters) === JSON.stringify(data)) {
           return state;


### PR DESCRIPTION
## 📌 PR 개요

- 저장된 프롬프트 필터 삭제 구현
- 서버에 삭제 요청 보내면 리액트 쿼리 자동 패치
- zustand selectedFilters 자동 패치

## 🔍 관련 이슈

- Closes #129 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [X] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 주요 변경 내용을 리스트로 정리해주세요.

`ex`

- 로그인 API 연동 (`/api/login`) 추가
- 로그인 폼에서 이메일/비밀번호 유효성 검사 로직 추가
- 로그인 성공 시 JWT 토큰을 localStorage에 저장하도록 수정
- UI: 로그인 버튼 클릭 시 로딩 스피너 추가

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 저장된 필터 삭제 기능이 추가되었습니다.
  * 프리셋 선택 및 삭제 UI가 개선되었습니다. 휴지통 아이콘을 통해 더 쉽게 필터를 관리할 수 있습니다.

* **버그 수정**
  * 데이터 로딩 오류 메시지가 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->