### PR TITLE
feat: repo 선택 버튼 클릭 시 로그인 가드 구현(#184)

### DIFF
--- a/src/features/github/ui/OrganizationSelect.tsx
+++ b/src/features/github/ui/OrganizationSelect.tsx
@@ -5,22 +5,25 @@ import { useOrganizations } from '../hooks/useOrganizations';
 import Pagination from '@/shared/ui/Pagination';
 import { OrgListSkeleton } from '@/shared/ui/loding/OrgListSkeleton';
 import NoData from '@/shared/ui/NoData';
+
 interface OrganizationSelectProps {
   setSelectedOrg: (org: { type: 'org' | 'user'; login: string }) => void;
 }
 export const OrganizationSelect = ({ setSelectedOrg }: OrganizationSelectProps) => {
   const [page, setPage] = useState(1);
   const { data: orgs, refetch, isLoading, isFetched } = useOrganizations(page);
-
   if (isLoading) {
     return <OrgListSkeleton count={5} />;
   }
 
-  if (!orgs)
+  if (!orgs || orgs.data.length === 0) {
     return (
-      <NoData message="데이터를 불러올 수 없습니다" description="로그인 상태를 확인해주세요" />
+      <NoData
+        message="조직이나 사용자 정보를 불러올 수 없습니다."
+        description="GitHub 계정의 조직/사용자 정보를 확인해주세요."
+      />
     );
-
+  }
   return (
     <>
       <ul className="grid grid-cols-1 gap-3">

--- a/src/features/github/ui/PullRequestFetch.tsx
+++ b/src/features/github/ui/PullRequestFetch.tsx
@@ -14,6 +14,7 @@ import { GeminiResponse, useCallN8nWebhook } from '@/features/n8n/hooks/useCallN
 import { usePrStore } from '@/shared/stores/usePrStore';
 import { usedocumentStore } from '@/shared/stores/useDocumentStore';
 import { usePromptFilterStore } from '@/shared/stores/usePromptFilterStore';
+import { useMe } from '@/features/auth/hooks/useMe';
 
 export const PullRequestFetch = () => {
   const { open, close } = useModal();
@@ -22,6 +23,7 @@ export const PullRequestFetch = () => {
   const { selectedPrUrl } = usePrStore();
   const { setDocument, setChartHtml, setPending, setError, isPending } = usedocumentStore();
   const { selectedFilters } = usePromptFilterStore();
+  const { data: me } = useMe();
 
   const handleGenerateFromSelect = () => {
     if (!selectedPrUrl) {
@@ -46,25 +48,27 @@ export const PullRequestFetch = () => {
     );
   };
 
+  const handleSelectRepository = () => {
+    if (!me) {
+      modal.alert('로그인이 필요합니다.');
+      return;
+    }
+    const id = open({
+      component: (
+        <Modal.Content>
+          <Modal.Body>
+            <PullRequestStepWrap onClose={() => close(id)} />
+          </Modal.Body>
+        </Modal.Content>
+      ),
+    });
+  };
+
   return (
     <section className="space-y-4">
       <div className="flex items-center justify-between">
         <h2 className="text-xl font-bold border-l-5 border-primary pl-2">PR 불러오기</h2>
-        <Button
-          onClick={() => {
-            const id = open({
-              component: (
-                <Modal.Content>
-                  <Modal.Body>
-                    <PullRequestStepWrap onClose={() => close(id)} />
-                  </Modal.Body>
-                </Modal.Content>
-              ),
-            });
-          }}
-        >
-          repository 선택
-        </Button>
+        <Button onClick={() => handleSelectRepository()}>repository 선택</Button>
       </div>
       <PullRequsetSearch onSearch={setSearchQuery} />
       <PullRequsetSelect searchQuery={searchQuery} />


### PR DESCRIPTION
## 📌 PR 개요

-  repo 선택 버튼 클릭 시 로그인 가드 구현

## 🔍 관련 이슈

- Closes #184 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 주요 변경 내용을 리스트로 정리해주세요.

`ex`

- 로그인 API 연동 (`/api/login`) 추가
- 로그인 폼에서 이메일/비밀번호 유효성 검사 로직 추가
- 로그인 성공 시 JWT 토큰을 localStorage에 저장하도록 수정
- UI: 로그인 버튼 클릭 시 로딩 스피너 추가

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

<img width="650" height="305" alt="image" src="https://github.com/user-attachments/assets/f8220e3e-61c0-41d0-af27-3a3ac8245e75" />

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 조직 정보 로드 실패 시 더 명확한 오류 메시지 제공
  * 빈 데이터 처리 개선

* **새로운 기능**
  * 풀 요청 선택 시 로그인 인증 필수 적용
  * 미로그인 사용자에게 알림 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->