### PR TITLE
feat: 나의 공방 목록에 내 데이터 연결 (#213)

### DIFF
--- a/src/app/[username]/posts/page.tsx
+++ b/src/app/[username]/posts/page.tsx
@@ -1,16 +1,9 @@
-import PostAside from '@/features/posts/PostAside';
-import PostList from '@/features/posts/PostList';
+import { PostContents } from '@/features/posts/PostContents';
 
-export default async function PostsPage({ params }: { params: Promise<{ username: string }> }) {
-  const { username } = await params;
-
+export default async function PostsPage() {
   return (
-    <div className="container mx-auto flex flex-col md:flex-row gap-3">
-      <PostAside />
-      <section className="flex-1">
-        <p>현재 경로의 유저: {username}</p>
-        <PostList />
-      </section>
+    <div className="container mx-auto flex flex-col md:flex-row gap-10">
+      <PostContents />
     </div>
   );
 }

--- a/src/app/api/me/route.ts
+++ b/src/app/api/me/route.ts
@@ -9,7 +9,7 @@ export async function GET() {
   const accessToken = cookieStore.get('access_token')?.value;
 
   if (!accessToken) {
-    return NextResponse.json(null, { status: 200 });
+    return NextResponse.json(null, { status: 401 });
   }
 
   try {

--- a/src/app/api/posts/route.ts
+++ b/src/app/api/posts/route.ts
@@ -1,0 +1,24 @@
+import { ProjectWithAnalyses } from '@/features/posts/model/posts';
+import { serverApi } from '@/shared/api/server/serverApi';
+import { verifyAccessToken } from '@/shared/auth/verifyAccessToken';
+import { cookies } from 'next/headers';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('access_token')?.value;
+
+  if (!accessToken) {
+    return NextResponse.json({ message: '로그인이 필요합니다.' }, { status: 401 });
+  }
+  try {
+    const { user_id } = verifyAccessToken(accessToken);
+    const data = await serverApi<ProjectWithAnalyses[]>(
+      `/projects?user_id=eq.${user_id}&select=id,repo_name,repo_owner,user_id,analyses(*)`,
+    );
+
+    return NextResponse.json(data);
+  } catch (e) {
+    return NextResponse.json({ message: '데이터 조회에 실패했습니다.' }, { status: 500 });
+  }
+}

--- a/src/features/posts/PostAside.tsx
+++ b/src/features/posts/PostAside.tsx
@@ -1,25 +1,44 @@
-const repolist = [
-  '전체보기',
-  'dev-craft',
-  'YY-Studio',
-  '말줌임테스트말줌임테스트말줌임테스트말줌임테스트말줌임테스트말줌임테스트말줌임테스트',
-];
-export default function PostAside() {
+'use client';
+import { ProjectWithAnalyses } from './model/posts';
+
+interface PostAsideProps {
+  posts: ProjectWithAnalyses[];
+  setSelectRepo: (repo: string) => void;
+}
+
+export default function PostAside({ posts, setSelectRepo }: PostAsideProps) {
+  // 나와야하는것: 전체보기, repo 이름들, repo갯수들
+
+  const handelSelectRepo = (repo: string) => {
+    setSelectRepo(repo);
+  };
   return (
     <aside className="w-full md:w-50">
       <h2 className="hidden md:block text-base text-gray-700 font-semibold border-b border-gray-400 pb-3 mb-3">
         레포지토리 목록
       </h2>
       <ul className="flex md:flex-col gap-1.5 overflow-auto pb-2 md:pb-0">
-        {repolist.map((repo) => (
+        <li className="flex md:block border border-gray-300 md:border-0 px-2 py-1 md:px-0 md:py-0 rounded-full md:rounded-none text-xs md:text-sm text-gray-700">
+          {' '}
+          <button
+            onClick={() => handelSelectRepo('all')}
+            className="flex-1 md:max-w-4/5 text-left hover:text-primary cursor-pointer whitespace-nowrap md:truncate"
+          >
+            전체보기
+          </button>
+        </li>
+        {posts.map((post) => (
           <li
-            key={repo}
+            key={post.repo_name}
             className="flex md:block border border-gray-300 md:border-0 px-2 py-1 md:px-0 md:py-0 rounded-full md:rounded-none text-xs md:text-sm text-gray-700"
           >
-            <button className="flex-1 md:max-w-4/5 text-left hover:text-primary cursor-pointer whitespace-nowrap md:truncate">
-              {repo}
+            <button
+              onClick={() => handelSelectRepo(post.repo_name)}
+              className="flex-1 md:max-w-4/5 text-left hover:text-primary cursor-pointer whitespace-nowrap md:truncate"
+            >
+              {post.repo_name}
             </button>
-            <span className=" ml-0.5">(12)</span>
+            <span className=" ml-0.5">{`(${post.analyses.length})`}</span>
           </li>
         ))}
       </ul>

--- a/src/features/posts/PostCard.tsx
+++ b/src/features/posts/PostCard.tsx
@@ -2,18 +2,25 @@ import IconLike from '@/shared/assets/icons/icon_like.svg';
 import IconComments from '@/shared/assets/icons/icon_comments.svg';
 import Link from 'next/link';
 import { Tag } from '@/shared/ui/Tag';
+import { Analysis, ProjectWithAnalyses } from './model/posts';
 const tags = ['Gemini', 'n8n', 'React', 'Figma', '해커톤'];
-export default function PostCard() {
+
+interface PostCardProps {
+  post: ProjectWithAnalyses;
+  analyses: Analysis;
+}
+
+export default function PostCard({ analyses, post }: PostCardProps) {
   return (
     <div className="flex-1 border border-gray-200 rounded-lg p-6">
       <div className="flex items-center gap-2">
         {/* {user?.avatar_url && <img src={user?.avatar_url} alt="" />} */}
         <img src="/globe.svg" alt="YY-studio" className="w-6 h-6" />
-        <div className="flex flex-col">
+        <div className="flex flex-col items-start">
           <button className="text-xs md:text-sm font-semibold hover:underline">
-            YY-Studiso/dev-craft
+            {`${post.repo_owner} / ${post.repo_name}`}
           </button>
-          <span className="text-xs text-gray-500">2026.03.04</span>
+          <span className="text-xs text-gray-500">{analyses.created_at.slice(0, 10)}</span>
         </div>
       </div>
       <div className="mt-6 space-y-5">
@@ -25,28 +32,24 @@ export default function PostCard() {
           />
         </Link>
         <Link href={'#'} className="text-xl md:text-2xl font-semibold hover:underline">
-          's' 하나 때문에 API가 터졌던 이야기
+          {analyses.title}
         </Link>
         <div className="text-sm md:text-base line-clamp-2 text-gray-500 mt-2.5">
-          솔직히 말하면 이 프로젝트는 조코딩 해커톤 제출 마감이 코앞이라 반쯤 패닉 상태로
-          만들었다.기획은 진작에 해뒀는데 막상 구현하려니 시간이 없었고 그냥 “일단 되게 만들자”는
-          마음으로 달렸다.개발자 공방은 GitHub PR URL 하나 넣으면 블로그 글이랑 README를자”는
-          마음으로 달렸다.개발자 공방은 GitHub PR URL 하나 넣으면 블로그 글이랑 README를자”는
-          마음으로 달렸다.개발자 공방은 GitHub PR URL 하나 넣으면 블로그 글이랑 README를자”는
-          마음으로 달렸다.개발자 공방은 GitHub PR URL 하나 넣으면 블로그 글이랑 README를자”는
-          마음으로 달렸다.개발자 공방은 GitHub PR URL 하나 넣으면 블로그 글이랑 README를
+          {analyses.content}
         </div>
         <ul className="flex items-center gap-2 flex-wrap">
-          {tags.map((tag) => (
+          {analyses.tags?.map((tag) => (
             <Tag key={tag} label={tag} />
           ))}
         </ul>
         <div className="flex items-center gap-3">
           <div className="flex items-center gap-0.5 text-xs md:text-sm">
-            <img src={IconLike.src} alt="좋아요" className="w-4 h-4 md:w-6 md:h-6" />3
+            <img src={IconLike.src} alt="좋아요" className="w-4 h-4 md:w-6 md:h-6" />
+            {analyses.likes_count}
           </div>
           <div className="flex items-center gap-0.5 text-xs md:text-sm">
-            <img src={IconComments.src} alt="댓글" className="w-4 h-4 md:w-6 md:h-6" />3
+            <img src={IconComments.src} alt="댓글" className="w-4 h-4 md:w-6 md:h-6" />
+            {analyses.views_count}
           </div>
         </div>
       </div>

--- a/src/features/posts/PostContents.tsx
+++ b/src/features/posts/PostContents.tsx
@@ -1,0 +1,21 @@
+'use client';
+import { useState } from 'react';
+import { usePosts } from './hooks/usePosts';
+import PostAside from './PostAside';
+import PostList from './PostList';
+import { ProjectWithAnalyses, Analysis } from './model/posts';
+
+export const PostContents = () => {
+  const { data: posts, isPending, isError } = usePosts();
+  const [selectRepo, setSelectRepo] = useState<string>('all');
+  const filteredPost =
+    selectRepo === 'all' ? posts : posts?.filter((post) => post.repo_name === selectRepo);
+  return (
+    <>
+      <PostAside posts={posts ?? []} setSelectRepo={setSelectRepo} />
+      <section className="flex-1">
+        <PostList posts={filteredPost ?? []} />
+      </section>
+    </>
+  );
+};

--- a/src/features/posts/PostList.tsx
+++ b/src/features/posts/PostList.tsx
@@ -1,8 +1,20 @@
+'use client';
+
+import { ProjectWithAnalyses, Analysis } from './model/posts';
 import PostCard from './PostCard';
-export default function PostList() {
+
+interface PostListProps {
+  posts: ProjectWithAnalyses[];
+}
+
+export default function PostList({ posts }: PostListProps) {
   return (
     <div className="flex flex-col gap-6">
-      <PostCard />
+      {posts?.flatMap((post) =>
+        post.analyses.map((analyses) => (
+          <PostCard key={analyses.id} post={post} analyses={analyses} />
+        )),
+      )}
     </div>
   );
 }

--- a/src/features/posts/hooks/usePosts.ts
+++ b/src/features/posts/hooks/usePosts.ts
@@ -1,0 +1,17 @@
+import { useQuery } from '@tanstack/react-query';
+import { ProjectWithAnalyses } from '@/features/posts/model/posts';
+import { clientApi } from '@/shared/api/client/clientApi';
+
+export const usePosts = () => {
+  return useQuery<ProjectWithAnalyses[] | null>({
+    queryKey: ['posts'],
+    queryFn: async (): Promise<ProjectWithAnalyses[] | null> => {
+      try {
+        return await clientApi<ProjectWithAnalyses[]>('posts');
+      } catch {
+        return null;
+      }
+    },
+    staleTime: 1000 * 60 * 5, // 5분간 캐시
+  });
+};

--- a/src/features/posts/model/posts.ts
+++ b/src/features/posts/model/posts.ts
@@ -1,0 +1,24 @@
+export interface Analysis {
+  id: string;
+  project_id: string;
+  user_id: string;
+  title: string;
+  content: string;
+  thumbnail_url: string | null;
+  created_at: string;
+  updated_at: string | null;
+  is_author_verified: boolean;
+  tags: string[] | null;
+  views_count: number;
+  likes_count: number;
+  pr_url: string;
+  visibility: boolean;
+}
+
+export interface ProjectWithAnalyses {
+  id: string;
+  repo_name: string;
+  repo_owner: string;
+  user_id: string;
+  analyses: Analysis[];
+}


### PR DESCRIPTION
## 📌 PR 개요

- 나의 공방 목록에 내 데이터 연결

## 🔍 관련 이슈

- Closes #213

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

## 작업 내용
- 로그인한 사용자의 projects + analyses 데이터를 조회하는 API 연결
- React Query 기반 게시글 목록 조회 훅 분리
- projects 내부 analyses를 펼쳐 카드 리스트로 렌더링하도록 구조 수정
- 레포지토리 목록/개수 계산 및 선택한 레포 기준 필터링 상태 추가
- 나의 공방 화면을 실제 데이터 기반으로 연결

## 핵심 변경
- `/api/my-workshop` 데이터 조회 로직 추가
- `usePosts` 훅 분리 및 목록 컴포넌트 연동
- `PostAside`, `PostList`, `PostCard` props 구조 정리
- 프로젝트별 analyses 기준 렌더링 처리

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [ ] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 게시물 페이지가 이제 사용자의 게시물을 동적으로 표시합니다.
  * 저장소별로 게시물을 필터링할 수 있는 기능이 추가되었습니다.

* **버그 수정**
  * 인증 토큰이 없을 때 API가 올바른 상태 코드(401)를 반환하도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->