### PR TITLE
feat: feed 태그검색, 데이터없음, 스켈레톤 구현(#231)

### DIFF
--- a/src/app/api/feeds/route.ts
+++ b/src/app/api/feeds/route.ts
@@ -9,7 +9,12 @@ export async function GET(req: Request) {
   const offset = searchParams.get('offset') ?? '0';
   const PAGE_SIZE = 2;
   try {
-    const filter = query ? `&title=ilike.*${query}*` : '';
+    let filter = '';
+    if (query) {
+      const safeQuery = encodeURIComponent(query);
+
+      filter = `&or=(title.ilike.*${safeQuery}*,tags_text.ilike.*${safeQuery}*)`;
+    }
 
     const base = `id,title,content,thumbnail_url,likes_count,created_at,tags,is_author_verified,users(username,avatar_url)`;
 

--- a/src/features/feed/FeedCard.tsx
+++ b/src/features/feed/FeedCard.tsx
@@ -2,6 +2,7 @@
 
 import { FeedCardProps } from './model/types';
 import Link from 'next/link';
+import { Tag } from '@/shared/ui/Tag';
 
 export function FeedCard({ post }: FeedCardProps) {
   return (
@@ -40,6 +41,11 @@ export function FeedCard({ post }: FeedCardProps) {
             <span>{post.likes_count}</span>
           </div>
         </div>
+        <ul className="flex gap-2 mt-5">
+          {post.tags.map((tag) => (
+            <Tag key={tag} label={tag} size="sm" />
+          ))}
+        </ul>
       </Link>
     </div>
   );

--- a/src/features/feed/FeedList.tsx
+++ b/src/features/feed/FeedList.tsx
@@ -4,17 +4,33 @@ import { useInView } from 'react-intersection-observer';
 import { FeedCard } from './FeedCard';
 import { useFeedPosts } from './hooks/useFeedPosts';
 import { useEffect } from 'react';
+import NoData from '@/shared/ui/NoData';
+import { FeedSkeleton } from '@/shared/ui/loding/FeedSkeleton';
 
 export function FeedList() {
   const { ref, inView } = useInView();
   const { data: posts, fetchNextPage, hasNextPage, isFetchingNextPage, isLoading } = useFeedPosts();
   const post = posts?.pages.flat() ?? [];
-  console.log(post);
+  console.log('feed', post);
   useEffect(() => {
     if (inView && hasNextPage && !isFetchingNextPage) {
       fetchNextPage();
     }
   }, [inView, hasNextPage, isFetchingNextPage]);
+
+  if (isLoading) {
+    return <FeedSkeleton count={4} />;
+  }
+
+  if (post.length === 0) {
+    return (
+      <NoData
+        message="검색 결과가 없습니다."
+        description="다른 검색어나 태그로 다시 검색해 보세요."
+        className="w-full mt-10"
+      />
+    );
+  }
 
   return (
     <>

--- a/src/shared/ui/loding/FeedSkeleton.tsx
+++ b/src/shared/ui/loding/FeedSkeleton.tsx
@@ -1,0 +1,34 @@
+export const FeedSkeleton = ({ count = 4 }: { count?: number }) => {
+  return (
+    <div className="grid grid-cols-1 gap-5 mt-5 w-full">
+      {Array.from({ length: count }).map((_, i) => (
+        <div key={i} className="border border-gray-200 rounded-lg p-6 bg-white animate-pulse">
+          <div className="h-6 w-3/4 max-w-md bg-gray-200 rounded mb-3" />
+
+          <div className="space-y-2 mb-4">
+            <div className="h-4 w-full bg-gray-200 rounded" />
+            <div className="h-4 w-5/6 bg-gray-200 rounded" />
+          </div>
+
+          <div className="h-3 w-20 bg-gray-200 rounded mb-4" />
+
+          <div className="flex items-center justify-between mb-5">
+            <div className="flex items-center gap-2">
+              <div className="w-5 h-5 bg-gray-300 rounded" />
+              <div className="h-4 w-24 bg-gray-200 rounded" />
+            </div>
+            <div className="h-4 w-8 bg-gray-200 rounded" />
+          </div>
+
+          {/* 5. 태그 영역 */}
+          <div className="flex items-center gap-2">
+            <div className="h-7 w-16 bg-gray-100 rounded-full" />
+            <div className="h-7 w-12 bg-gray-100 rounded-full" />
+            <div className="h-7 w-20 bg-gray-100 rounded-full" />
+            <div className="h-7 w-14 bg-gray-100 rounded-full" />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+};


### PR DESCRIPTION
## 📌 PR 개요

feed 태그가 안나오고있음
feed 태그로 검색이 안되고있어요
검색결과가 없을때 nodata컴포넌트 안나오고 있어요
feed 페이지 스켈레톤 구현

## 🔍 관련 이슈

- Closes #231 

## 🔧 변경 유형

해당하는 항목에 체크해주세요.

- [x] ✨ feat (새 기능 추가)
- [ ] 🐛 fix (버그 수정)
- [ ] 📝 docs (문서 수정)
- [ ] 🎨 style (코드 스타일 변경)
- [ ] ♻️ refactor (리팩토링)
- [ ] ✅ test (테스트 코드)
- [ ] 🛠 chore (빌드/환경설정)

## ✨ 변경 사항

- 주요 변경 내용을 리스트로 정리해주세요.

`ex`

- 로그인 API 연동 (`/api/login`) 추가
- 로그인 폼에서 이메일/비밀번호 유효성 검사 로직 추가
- 로그인 성공 시 JWT 토큰을 localStorage에 저장하도록 수정
- UI: 로그인 버튼 클릭 시 로딩 스피너 추가

## 📝 PR 제목 규칙

PR 제목은 커밋 컨벤션을 따라야 합니다.  
ex) feat: 롤링페이퍼 작성 기능 추가 (#15)

## ✅ 체크리스트

- [x] 코드가 정상 동작함
- [ ] 빌드 및 실행 확인 완료
- [ ] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

- UI 변경이 있다면 캡처 이미지 첨부

## 🤝 기타 참고 사항

- 리뷰어가 참고하면 좋을 추가 맥락(설계 의도, 제약사항 등)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 피드 검색 범위 확대: 제목뿐 아니라 태그도 함께 검색 가능
  * 게시물 카드에 태그 표시 추가
  * 로딩 중 스켈레톤 UI 표시
  * 검색 결과가 없을 때 안내 메시지 표시

<!-- end of auto-generated comment: release notes by coderabbit.ai -->