### PR TITLE
feat: like count, 낙관적 업데이트 (#229)

### DIFF
--- a/src/app/api/post-like/[id]/route.ts
+++ b/src/app/api/post-like/[id]/route.ts
@@ -1,0 +1,60 @@
+import { cookies } from 'next/headers';
+import { verifyAccessToken } from '@/shared/auth/verifyAccessToken';
+import { NextRequest, NextResponse } from 'next/server';
+import { serverApi } from '@/shared/api/server/serverApi';
+
+async function getUserId() {
+  const cookieStore = await cookies();
+  const accessToken = cookieStore.get('access_token')?.value;
+  if (!accessToken) return null;
+  const { user_id } = verifyAccessToken(accessToken);
+  return user_id;
+}
+
+type Like = { id: string; user_id: string; analysis_id: string };
+
+// 좋아요 수 + 내가 눌렀는지
+export async function GET(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const user_id = await getUserId();
+
+  const likes = await serverApi<Like[]>(`/likes?analysis_id=eq.${id}`);
+
+  return NextResponse.json({
+    count: likes.length,
+    isLiked: user_id ? likes.some((l) => l.user_id === user_id) : false,
+  });
+}
+
+// 좋아요 추가
+export async function POST(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const user_id = await getUserId();
+  if (!user_id) return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+
+  try {
+    await serverApi('/likes', {
+      method: 'POST',
+      body: { analysis_id: id, user_id },
+    });
+    return NextResponse.json({ success: true });
+  } catch (e) {
+    return NextResponse.json({ message: '좋아요에 실패했습니다.' }, { status: 500 });
+  }
+}
+
+// 좋아요 취소
+export async function DELETE(_req: NextRequest, { params }: { params: Promise<{ id: string }> }) {
+  const { id } = await params;
+  const user_id = await getUserId();
+  if (!user_id) return NextResponse.json({ message: '인증이 필요합니다.' }, { status: 401 });
+
+  try {
+    await serverApi(`/likes?analysis_id=eq.${id}&user_id=eq.${user_id}`, {
+      method: 'DELETE',
+    });
+    return NextResponse.json({ success: true });
+  } catch (e) {
+    return NextResponse.json({ message: '좋아요 취소에 실패했습니다.' }, { status: 500 });
+  }
+}

--- a/src/features/post-detail/PostDetail.tsx
+++ b/src/features/post-detail/PostDetail.tsx
@@ -3,6 +3,7 @@
 import Button from '@/shared/ui/Button';
 import { Tag } from '@/shared/ui/Tag';
 import IconLike from '@/shared/assets/icons/icon_like.svg';
+import IconLikeActive from '@/shared/assets/icons/icon_like_active.svg';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import { usePostDetail } from './hooks/usePostDetail';
@@ -13,6 +14,8 @@ import { modal } from '@/shared/ui/modal/modalApi';
 import { useRouter } from 'next/navigation';
 import { useDeletePost } from './hooks/useDeletePost';
 import { useMe } from '../auth/hooks/useMe';
+import { useLike } from './hooks/useLike';
+import { cn } from '@/shared/lib/cn';
 
 interface PostDetailProps {
   id: string;
@@ -23,6 +26,7 @@ export default function PostDetail({ id }: PostDetailProps) {
   const { mutate: deletePost, isPending: isDeleting } = useDeletePost();
   const { data: me } = useMe();
   const isOwner = me?.username === data?.users.username;
+  const { count, isLiked, toggleLike } = useLike(id);
 
   const handleDelete = async () => {
     const confirmed = await modal.confirm('정말 삭제하시겠습니까?', {
@@ -71,10 +75,17 @@ export default function PostDetail({ id }: PostDetailProps) {
           </Link>
           <span className="text-xs text-gray-400">{data.created_at.slice(0, 10)}</span>
         </div>
-        <div className="ml-auto flex items-center gap-0.5 text-xs md:text-sm">
-          <img src={IconLike.src} alt="좋아요" className="w-4 h-4 md:w-5 md:h-5" />
-          {data.likes_count}
-        </div>
+        <button
+          onClick={() => toggleLike()}
+          className="ml-auto flex items-center gap-0.5 text-xs md:text-sm"
+        >
+          <img
+            src={isLiked ? IconLikeActive.src : IconLike.src}
+            alt="좋아요"
+            className="w-4 h-4 md:w-5 md:h-5"
+          />
+          {count}
+        </button>
         {isOwner && (
           <Button variant="gray" size="sm" onClick={handleDelete} disabled={isDeleting}>
             {isDeleting ? '삭제 중...' : '삭제'}

--- a/src/features/post-detail/hooks/useLike.ts
+++ b/src/features/post-detail/hooks/useLike.ts
@@ -1,0 +1,35 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { clientApi } from '@/shared/api/client/clientApi';
+
+type LikeResponse = { count: number; isLiked: boolean };
+
+export const useLike = (id: string) => {
+  const queryClient = useQueryClient();
+
+  const { data } = useQuery<LikeResponse>({
+    queryKey: ['like', id],
+    queryFn: () => clientApi(`post-like/${id}`),
+  });
+
+  const { mutate: toggleLike } = useMutation({
+    mutationFn: () =>
+      clientApi(`post-like/${id}`, {
+        method: data?.isLiked ? 'DELETE' : 'POST',
+      }),
+    onMutate: async () => {
+      // 낙관적 업데이트
+      await queryClient.cancelQueries({ queryKey: ['like', id] });
+      const prev = queryClient.getQueryData<LikeResponse>(['like', id]);
+      queryClient.setQueryData(['like', id], {
+        count: prev!.count + (prev!.isLiked ? -1 : 1),
+        isLiked: !prev!.isLiked,
+      });
+      return { prev };
+    },
+    onError: (_err, _vars, context) => {
+      queryClient.setQueryData(['like', id], context?.prev);
+    },
+  });
+
+  return { count: data?.count ?? 0, isLiked: data?.isLiked ?? false, toggleLike };
+};


### PR DESCRIPTION
## 📌 PR 개요
> 포스트 상세 페이지에서 좋아요 및 좋아요 취소 기능을 구현합니다.
> 낙관적 업데이트를 적용해 서버 응답 없이 UI가 즉시 반응합니다.

## 🔍 관련 이슈
- Closes #229

## 🔧 변경 유형
- [x] ✨ feat (새 기능 추가)

## ✨ 변경 사항
- `likes` 테이블 생성 (user_id, analysis_id, unique 제약 조건)
- `GET /api/post-like/[id]` - 좋아요 수 및 본인 좋아요 여부 조회
- `POST /api/post-like/[id]` - 좋아요 추가
- `DELETE /api/post-like/[id]` - 좋아요 취소
- `useLike` 훅 추가 (React Query `useMutation` + 낙관적 업데이트)
- 좋아요 상태에 따라 `icon_like.svg` / `icon_like_active.svg` 분기 처리
- 비로그인 시 좋아요 불가 (401 반환)

## ✅ 체크리스트
- [x] 코드가 정상 동작함
- [x] 빌드 및 실행 확인 완료
- [x] 리뷰어가 이해하기 쉽게 변경 이유를 설명했음

## 📸 스크린샷 (선택)

## 🤝 기타 참고 사항
- `likes_count` 컬럼 대신 `likes` 테이블 row 수를 실시간으로 카운트하는 방식 채택
- 낙관적 업데이트로 버튼 클릭 즉시 UI 반영, 실패 시 이전 상태로 롤백

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 새로운 기능

* **게시물 좋아요 기능**: 사용자가 관심 있는 게시물에 좋아요를 표시하고 취소할 수 있습니다.
* **좋아요 수 표시**: 각 게시물의 총 좋아요 수를 실시간으로 확인할 수 있습니다.
* **개인 좋아요 상태 표시**: 내가 해당 게시물에 좋아요를 했는지 여부를 쉽게 파악할 수 있습니다.
* **빠른 응답 처리**: 좋아요 또는 취소 시 화면이 즉시 업데이트되어 부드럽고 즉각적인 사용 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->